### PR TITLE
Add Metadata Remover to verification resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Tools are useful, but they do not replace analysis.
 
 * Reverse image search
 * Metadata viewers
+* [Metadata Remover](https://metadataremover.ai/metadata-viewer) — Browser-local viewer for EXIF, GPS, XMP, IPTC, and supported AI metadata; no uploads or account required.
 * Map comparison
 * Shadow and weather checking
 * Frame-by-frame inspection


### PR DESCRIPTION
Disclosure: I maintain [Metadata Remover](https://metadataremover.ai/metadata-viewer).

This adds one browser-local image metadata viewer to the existing Image & Video Verification resources. It reads EXIF, GPS, XMP, IPTC, and supported AI metadata from JPG, PNG, and WebP files without uploads or an account. The PR contains one factual list item.