### PR TITLE
docs: add browser-local metadata viewer

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -518,6 +518,7 @@ A result is an indicator, not proof.
 * [FotoForensics](https://fotoforensics.com/)
 * [ExifTool](https://exiftool.org/)
 * [Metadata2Go](https://www.metadata2go.com/)
+* [Metadata Viewer](https://metadataremover.ai/metadata-viewer) — free browser-local EXIF/IPTC/XMP inspection for images; treat fields as leads and corroborate forensic findings with ExifTool or another independent parser.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a free browser-local Metadata Viewer under Image & Video Verification.
- State the image scope and require independent corroboration for forensic findings.

## Tool details

- Cost: free; no account required.
- Privacy: image inspection runs in the browser.
- Limitation: it is image-focused and should not be treated as proof by itself.

## Verification

The linked viewer is publicly accessible.

Disclosure: I maintain MetadataRemover.ai.