### PR TITLE
chore: upgrade GitHub Actions to Node 24-compatible releases

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check links with Lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@v2.9.0
         with:
           args: >-
             --config lychee.toml

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload site
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/tool-catalog.yml
+++ b/.github/workflows/tool-catalog.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: Validate tool catalogue

--- a/docs/.qa-actions-update-marker
+++ b/docs/.qa-actions-update-marker
@@ -1,1 +1,0 @@
-Step 1 QA marker: GitHub Actions runtime upgrade branch.

--- a/docs/.qa-actions-update-marker
+++ b/docs/.qa-actions-update-marker
@@ -1,0 +1,1 @@
+Step 1 QA marker: GitHub Actions runtime upgrade branch.


### PR DESCRIPTION
## Step 1 — Update Actions to latest stable majors

This PR upgrades the repository workflows to current stable action generations that run on Node 24-compatible runtimes.

- `actions/checkout`: v4 → v7
- `actions/setup-python`: v5 → v7
- `actions/configure-pages`: v5 → v6
- `actions/upload-pages-artifact`: v3 → v5
- `actions/deploy-pages`: v4 → v5
- `lycheeverse/lychee-action`: floating v2 → v2.9.0

No application or documentation content changes are included. The purpose is to remove the current Node 20 deprecation path before proceeding to the next QA hardening step.