### PR TITLE
fix: clean legacy dead links and replace broken workflow image

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -671,8 +671,8 @@ intitle:"report" "company name"
 * GIJN Investigative Tools
   https://gijn.org/resource/
 
-* First Draft Verification Toolbox — أرشيف تعليمي
-  https://firstdraftnews.org/verification-toolbox/
+* Verification Handbook — متوفر بالعربية والتركية
+  https://verificationhandbook.com/
 
 ---
 

--- a/README.ar.md
+++ b/README.ar.md
@@ -348,7 +348,7 @@ intitle:"report" "company name"
 
 ## 🔁 سير عمل OSINT
 
-![Workflow](https://images.unsplash.com/photo-1517430816045-df4b7de01aab)
+![OSINT Workflow](assets/osint-workflow.svg)
 
 ```text
 1. تحديد الهدف
@@ -663,7 +663,7 @@ intitle:"report" "company name"
   https://osintcurio.us/
 
 * FreeOSINT
-  https://www.freeosint.org/
+  https://freeosint.github.io/
 
 * Google Search Help
   https://support.google.com/websearch/
@@ -671,8 +671,8 @@ intitle:"report" "company name"
 * GIJN Investigative Tools
   https://gijn.org/resource/
 
-* First Draft / Verification Resources
-  https://firstdraftnews.org/
+* First Draft Verification Toolbox — أرشيف تعليمي
+  https://firstdraftnews.org/verification-toolbox/
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -400,7 +400,7 @@ This cannot be proven with the available evidence.
 
 ## 🔁 OSINT Workflow
 
-![Workflow](https://images.unsplash.com/photo-1517430816045-df4b7de01aab)
+![OSINT Workflow](assets/osint-workflow.svg)
 
 ```text
 1. Define the intelligence question
@@ -708,7 +708,7 @@ Use confidence levels to avoid overstating conclusions.
 * [Verification Handbook](https://verificationhandbook.com/)
 * [GIJN Resource Center](https://gijn.org/resource/)
 * [OSINTCurious](https://osintcurio.us/)
-* [FreeOSINT](https://www.freeosint.org/)
+* [FreeOSINT](https://freeosint.github.io/)
 * [Google Search Help](https://support.google.com/websearch/)
 * [Google Advanced Search](https://www.google.com/advanced_search)
 

--- a/assets/osint-workflow.svg
+++ b/assets/osint-workflow.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-labelledby="title desc">
+  <title id="title">OSINT investigation workflow</title>
+  <desc id="desc">A six-stage workflow: Question, Scope, Collect, Verify, Analyze, Report.</desc>
+  <rect width="1200" height="360" rx="28" fill="#0b1220"/>
+  <text x="70" y="72" fill="#f8fafc" font-family="system-ui,-apple-system,Segoe UI,sans-serif" font-size="34" font-weight="700">OSINT Investigation Workflow</text>
+  <text x="70" y="108" fill="#94a3b8" font-family="system-ui,-apple-system,Segoe UI,sans-serif" font-size="18">Question → scope → public-source collection → verification → analysis → defensible reporting</text>
+  <g font-family="system-ui,-apple-system,Segoe UI,sans-serif" text-anchor="middle">
+    <g transform="translate(70 165)"><rect width="150" height="100" rx="18" fill="#111c2f" stroke="#3b82f6" stroke-width="2"/><text x="75" y="45" fill="#60a5fa" font-size="16" font-weight="700">01</text><text x="75" y="72" fill="#f8fafc" font-size="21" font-weight="650">Question</text></g>
+    <g transform="translate(260 165)"><rect width="150" height="100" rx="18" fill="#111c2f" stroke="#38bdf8" stroke-width="2"/><text x="75" y="45" fill="#7dd3fc" font-size="16" font-weight="700">02</text><text x="75" y="72" fill="#f8fafc" font-size="21" font-weight="650">Scope</text></g>
+    <g transform="translate(450 165)"><rect width="150" height="100" rx="18" fill="#111c2f" stroke="#22c55e" stroke-width="2"/><text x="75" y="45" fill="#4ade80" font-size="16" font-weight="700">03</text><text x="75" y="72" fill="#f8fafc" font-size="21" font-weight="650">Collect</text></g>
+    <g transform="translate(640 165)"><rect width="150" height="100" rx="18" fill="#111c2f" stroke="#eab308" stroke-width="2"/><text x="75" y="45" fill="#facc15" font-size="16" font-weight="700">04</text><text x="75" y="72" fill="#f8fafc" font-size="21" font-weight="650">Verify</text></g>
+    <g transform="translate(830 165)"><rect width="150" height="100" rx="18" fill="#111c2f" stroke="#f97316" stroke-width="2"/><text x="75" y="45" fill="#fb923c" font-size="16" font-weight="700">05</text><text x="75" y="72" fill="#f8fafc" font-size="21" font-weight="650">Analyze</text></g>
+    <g transform="translate(1020 165)"><rect width="150" height="100" rx="18" fill="#111c2f" stroke="#a855f7" stroke-width="2"/><text x="75" y="45" fill="#c084fc" font-size="16" font-weight="700">06</text><text x="75" y="72" fill="#f8fafc" font-size="21" font-weight="650">Report</text></g>
+  </g>
+  <g stroke="#475569" stroke-width="3" fill="none" stroke-linecap="round"><path d="M220 215h38"/><path d="M410 215h38"/><path d="M600 215h38"/><path d="M790 215h38"/><path d="M980 215h38"/></g>
+  <g fill="#64748b"><path d="M252 208l12 7-12 7z"/><path d="M442 208l12 7-12 7z"/><path d="M632 208l12 7-12 7z"/><path d="M822 208l12 7-12 7z"/><path d="M1012 208l12 7-12 7z"/></g>
+  <text x="70" y="316" fill="#94a3b8" font-family="system-ui,-apple-system,Segoe UI,sans-serif" font-size="16">Use lawful public sources • preserve provenance • test alternatives • state confidence and limitations</text>
+</svg>

--- a/lychee.toml
+++ b/lychee.toml
@@ -16,10 +16,6 @@ exclude = [
   '^tel:',
   # Known automation-unfriendly / transient service.
   '^https://crt\.sh/?',
-  # Legacy links tracked for content cleanup rather than bot checking.
-  '^https://images\.unsplash\.com/photo-1517430816045-df4b7de01aab',
-  '^https://www\.freeosint\.org/?',
-  '^https://firstdraftnews\.org/?',
   # GitHub Pages is not live until repository Pages is enabled once.
   '^https://imedkablavi\.github\.io/OSINT-Roadmap/tool-finder\.html$'
 ]


### PR DESCRIPTION
## Step 2 — Remove/fix legacy dead links

This PR cleans legacy link debt instead of hiding broken references from QA.

### Fixed
- replaced the dead Unsplash workflow image with a local repository-owned SVG asset
- updated FreeOSINT from the obsolete `freeosint.org` domain to the current `https://freeosint.github.io/` site
- removed the unstable First Draft live-link dependency from the Arabic learning resources and replaced it with the current Verification Handbook resource
- removed the resolved Unsplash, FreeOSINT and First Draft exclusions from `lychee.toml`

### Intentionally still excluded
- `crt.sh` remains excluded because it is automation-unfriendly/transient rather than a dead documentation link
- the Tool Finder Pages URL remains excluded until GitHub Pages is enabled in step 11

### QA
Final Link Health run passed after the cleanup:
- 742 references checked
- 236 unique links
- 736 successful
- 0 errors
- 0 timeouts
- 6 intentional exclusions

The repaired resources now pass QA without legacy ignore rules.