### PR TITLE
ci: expand Link Health to the static site

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,12 +4,20 @@ on:
   pull_request:
     paths:
       - '**/*.md'
+      - 'site/**/*.html'
+      - 'site/**/*.css'
+      - 'site/**/*.xml'
+      - 'site/**/*.txt'
       - '.github/workflows/link-check.yml'
       - 'lychee.toml'
   push:
     branches: [main]
     paths:
       - '**/*.md'
+      - 'site/**/*.html'
+      - 'site/**/*.css'
+      - 'site/**/*.xml'
+      - 'site/**/*.txt'
       - '.github/workflows/link-check.yml'
       - 'lychee.toml'
   schedule:
@@ -21,7 +29,7 @@ permissions:
 
 jobs:
   links:
-    name: Check documentation links
+    name: Check documentation and site links
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -34,6 +42,10 @@ jobs:
             --config lychee.toml
             --no-progress
             './**/*.md'
+            './site/**/*.html'
+            './site/**/*.css'
+            './site/**/*.xml'
+            './site/**/*.txt'
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lychee.toml
+++ b/lychee.toml
@@ -16,6 +16,7 @@ exclude = [
   '^tel:',
   # Known automation-unfriendly / transient service.
   '^https://crt\.sh/?',
-  # GitHub Pages is not live until repository Pages is enabled once.
-  '^https://imedkablavi\.github\.io/OSINT-Roadmap/tool-finder\.html$'
+  # Temporary: Pages URLs are canonical/hreflang targets in site HTML but the site is
+  # not live until GitHub Pages is enabled in step 11. Relative site links are still checked locally.
+  '^https://imedkablavi\.github\.io/OSINT-Roadmap/'
 ]


### PR DESCRIPTION
## Step 3 — Expand link checking to the HTML/static site

This PR upgrades Link Health from Markdown-only coverage to repository documentation plus the static website.

### Coverage added
- `site/**/*.html`
- `site/**/*.css`
- `site/**/*.xml`
- `site/**/*.txt`

The workflow now also triggers when any of those site files change.

### Pages handling
The site already contains canonical and hreflang URLs targeting `https://imedkablavi.github.io/OSINT-Roadmap/`, but GitHub Pages is intentionally not enabled until step 11. Those unpublished absolute Pages URLs are temporarily excluded as a group. Relative site navigation and assets are still checked locally, so broken HTML links can fail CI now.

### QA result
The expanded Link Health run passed:
- 852 references checked
- 278 unique links
- 812 successful
- 38 redirects followed
- 0 errors
- 0 timeouts
- 40 exclusions, primarily unpublished Pages canonical/hreflang URLs plus the existing automation-unfriendly service rule

Before this step the Markdown-only run checked 742 references / 236 unique links, so the increased coverage confirms the static site is now part of CI.

### Not part of this step
- HTML standards validation is step 4.
- Browser/runtime behavior for Tool Finder is step 5.
- Live Pages smoke testing is step 6/11.