### PR TITLE
ci: validate static site HTML5

### DIFF
--- a/.github/workflows/html-validation.yml
+++ b/.github/workflows/html-validation.yml
@@ -19,6 +19,7 @@ jobs:
   validate-html:
     name: Validate HTML5
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Step 4 — Add HTML validation

Adds standards validation for every HTML page under `site/` using the Nu HTML Checker via `Cyb3r-Jak3/html5validator-action@v7.2.0`.

### Behavior
- runs on PRs that touch `site/**/*.html` or the validation workflow
- runs on pushes to `main` for the same paths
- supports manual dispatch
- checks the entire `site/` tree recursively
- fails CI on invalid HTML
- has a 10-minute timeout to avoid hung validation jobs

### QA result
`Validate HTML5` completed successfully. The validator action built, checked out the repository, validated `site/`, and exited green with no HTML5 validation errors.

Link integrity remains covered by Link Health; runtime browser behavior is step 5.