### PR TITLE
test: exercise Tool Finder in Chromium

### DIFF
--- a/.github/workflows/tool-finder-browser.yml
+++ b/.github/workflows/tool-finder-browser.yml
@@ -1,0 +1,47 @@
+name: Tool Finder Browser Test
+
+on:
+  pull_request:
+    paths:
+      - 'site/tool-finder.html'
+      - 'site/tools.json'
+      - 'site/style.css'
+      - 'tests/tool-finder.spec.js'
+      - 'playwright.config.js'
+      - '.github/workflows/tool-finder-browser.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'site/tool-finder.html'
+      - 'site/tools.json'
+      - 'site/style.css'
+      - 'tests/tool-finder.spec.js'
+      - 'playwright.config.js'
+      - '.github/workflows/tool-finder-browser.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  browser-test:
+    name: Chromium Tool Finder E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Install Playwright test runner
+        run: npm install --no-save --no-audit --no-fund @playwright/test@1.62.1
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Tool Finder browser tests
+        run: npx playwright test tests/tool-finder.spec.js --reporter=line

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,20 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  retries: 0,
+  workers: 1,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    browserName: 'chromium',
+    headless: true,
+  },
+  webServer: {
+    command: 'python3 -m http.server 4173 --directory site',
+    url: 'http://127.0.0.1:4173/tool-finder.html',
+    reuseExistingServer: false,
+    timeout: 15_000,
+  },
+});

--- a/tests/tool-finder.spec.js
+++ b/tests/tool-finder.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require('@playwright/test');
+
+async function openFinder(page) {
+  const browserErrors = [];
+  page.on('pageerror', error => browserErrors.push(`pageerror: ${error.message}`));
+  page.on('console', message => {
+    if (message.type() === 'error') browserErrors.push(`console: ${message.text()}`);
+  });
+
+  await page.goto('/tool-finder.html');
+  await expect(page.locator('#count')).toHaveText('80 of 80 curated tools');
+  await expect(page.locator('article.tool')).toHaveCount(80);
+  expect(browserErrors).toEqual([]);
+}
+
+test('loads the full curated catalogue without browser errors', async ({ page }) => {
+  await openFinder(page);
+
+  await expect(page.locator('#category option')).not.toHaveCount(1);
+  await expect(page.locator('#input option')).not.toHaveCount(1);
+  await expect(page.locator('#cost option')).not.toHaveCount(1);
+  await expect(page.locator('#level option')).not.toHaveCount(1);
+});
+
+test('search narrows results to a matching tool', async ({ page }) => {
+  await openFinder(page);
+
+  await page.locator('#q').fill('OCRmyPDF');
+  await expect(page.locator('#count')).toHaveText('1 of 80 curated tools');
+  await expect(page.locator('article.tool')).toHaveCount(1);
+  await expect(page.getByRole('heading', { name: 'OCRmyPDF', exact: true })).toBeVisible();
+});
+
+test('input filter only returns tools that accept the selected input', async ({ page }) => {
+  await openFinder(page);
+
+  await page.locator('#input').selectOption('Domain');
+  const cards = page.locator('article.tool');
+  const count = await cards.count();
+  expect(count).toBeGreaterThan(0);
+  expect(count).toBeLessThan(80);
+
+  for (let index = 0; index < count; index += 1) {
+    await expect(cards.nth(index).locator('.chip', { hasText: 'Domain' })).toHaveCount(1);
+  }
+});
+
+test('no-result state and reset behavior work', async ({ page }) => {
+  await openFinder(page);
+
+  await page.locator('#q').fill('__no_such_osint_tool__');
+  await expect(page.locator('#count')).toHaveText('0 of 80 curated tools');
+  await expect(page.locator('article.tool')).toHaveCount(0);
+  await expect(page.locator('.empty')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Reset filters' }).click();
+  await expect(page.locator('#count')).toHaveText('80 of 80 curated tools');
+  await expect(page.locator('article.tool')).toHaveCount(80);
+  await expect(page.locator('#q')).toHaveValue('');
+});
+
+test('rendered external tool links use safe new-tab attributes', async ({ page }) => {
+  await openFinder(page);
+
+  const links = page.locator('a.open');
+  await expect(links).toHaveCount(80);
+
+  const invalid = await links.evaluateAll(nodes => nodes
+    .map(node => ({
+      href: node.getAttribute('href'),
+      target: node.getAttribute('target'),
+      rel: node.getAttribute('rel') || '',
+    }))
+    .filter(link => !/^https:\/\//.test(link.href || '') || link.target !== '_blank' || !link.rel.includes('noopener') || !link.rel.includes('noreferrer')));
+
+  expect(invalid).toEqual([]);
+});


### PR DESCRIPTION
## Step 5 — Add Tool Finder browser test

Adds real-browser E2E coverage for `site/tool-finder.html` using Playwright 1.62.1 and Chromium.

### What is tested
- `tools.json` loads successfully in a browser
- all 80 curated tools render
- filter dropdowns populate dynamically
- text search narrows to the expected tool
- input filtering returns only compatible tools
- no-result state renders correctly
- Reset restores all tools and clears search
- all rendered external tool links use HTTPS, `_blank`, `noopener` and `noreferrer`
- JavaScript/page console errors fail the baseline load test

### CI
- Node.js 24 via `actions/setup-node@v7`
- Chromium installed by Playwright
- local static server started by Playwright config
- test runs on Tool Finder, catalogue, CSS, test/config, or workflow changes

### QA result
Chromium successfully loaded `tool-finder.html`, `style.css` and `tools.json` over the local HTTP server. Playwright executed 5 tests with 1 worker and reported `5 passed (3.1s)`.

Accessibility is handled separately in step 7.