### PR TITLE
ci: smoke-test the Pages deployment bundle

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,16 @@
 name: Deploy OSINT Roadmap Website
 
 on:
+  pull_request:
+    paths:
+      - 'site/**'
+      - 'scripts/pages_smoke.py'
+      - '.github/workflows/pages.yml'
   push:
     branches: [main]
     paths:
       - 'site/**'
+      - 'scripts/pages_smoke.py'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
@@ -14,24 +20,81 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  smoke:
+    name: Pages artifact smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Start local static server
+        run: |
+          python -m http.server 4173 --directory site > /tmp/osint-pages-server.log 2>&1 &
+          echo $! > /tmp/osint-pages-server.pid
+          for attempt in {1..20}; do
+            if curl --fail --silent --show-error http://127.0.0.1:4173/ > /dev/null; then
+              exit 0
+            fi
+            sleep 0.5
+          done
+          cat /tmp/osint-pages-server.log
+          exit 1
+
+      - name: Smoke test deployment bundle locally
+        run: python scripts/pages_smoke.py --base-url http://127.0.0.1:4173/
+
+      - name: Package exact Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  pages-disabled:
+    name: Pages enablement status
+    needs: smoke
+    if: ${{ github.event_name != 'pull_request' && github.event.repository.has_pages != true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped deployment
+        run: echo "::notice::GitHub Pages is not enabled yet. The exact site bundle passed its smoke test; live deployment is intentionally skipped until Pages is enabled in step 11."
+
   deploy:
+    name: Deploy and verify GitHub Pages
+    needs: smoke
+    if: ${{ github.event_name != 'pull_request' && github.event.repository.has_pages == true }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
       - name: Configure Pages
         uses: actions/configure-pages@v6
-      - name: Upload site
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: site
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Checkout smoke test
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Smoke test live deployment
+        run: >-
+          python scripts/pages_smoke.py
+          --base-url "${{ steps.deployment.outputs.page_url }}"
+          --retries 8
+          --retry-delay 5

--- a/scripts/pages_smoke.py
+++ b/scripts/pages_smoke.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Smoke-test the static OSINT Roadmap site over HTTP.
+
+The same checks run against a local server in pull requests and against the
+real GitHub Pages URL after deployment is enabled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from xml.etree import ElementTree
+
+EXPECTED_PAGES = {
+    "": "OSINT Roadmap",
+    "learn-osint.html": "OSINT",
+    "osint-tools.html": "OSINT",
+    "tool-finder.html": "OSINT Tool Finder",
+    "geoint-guide.html": "GEOINT",
+    "cti-osint.html": "OSINT",
+    "digital-footprint.html": "Digital",
+    "company-investigation.html": "Company",
+    "ar/": "OSINT",
+    "tr/": "OSINT",
+}
+
+STATIC_RESOURCES = (
+    "style.css",
+    "tools.json",
+    "robots.txt",
+    "sitemap.xml",
+    "feed.xml",
+)
+
+EXPECTED_PRODUCTION_ROOT = "https://imedkablavi.github.io/OSINT-Roadmap/"
+
+
+def url_for(base: str, path: str) -> str:
+    return urllib.parse.urljoin(base.rstrip("/") + "/", path)
+
+
+def fetch(url: str, retries: int, delay: float) -> tuple[bytes, str]:
+    last_error: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": "OSINT-Roadmap-Pages-Smoke/1.0"},
+            )
+            with urllib.request.urlopen(request, timeout=15) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"HTTP {response.status}")
+                return response.read(), response.headers.get("Content-Type", "")
+        except (urllib.error.URLError, TimeoutError, RuntimeError) as exc:
+            last_error = exc
+            if attempt < retries:
+                time.sleep(delay)
+    raise RuntimeError(f"failed to fetch {url}: {last_error}")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def run(base_url: str, retries: int, delay: float) -> None:
+    print(f"Smoke-testing {base_url}")
+
+    for path, marker in EXPECTED_PAGES.items():
+        body, content_type = fetch(url_for(base_url, path), retries, delay)
+        text = body.decode("utf-8", errors="replace")
+        require("text/html" in content_type, f"{path or '/'} is not HTML: {content_type}")
+        require(marker.lower() in text.lower(), f"{path or '/'} is missing marker: {marker}")
+        require("<html" in text.lower(), f"{path or '/'} does not look like HTML")
+        print(f"PASS page: /{path}")
+
+    resources: dict[str, bytes] = {}
+    for path in STATIC_RESOURCES:
+        body, _ = fetch(url_for(base_url, path), retries, delay)
+        require(len(body) > 0, f"{path} is empty")
+        resources[path] = body
+        print(f"PASS resource: /{path}")
+
+    tools = json.loads(resources["tools.json"].decode("utf-8"))
+    require(isinstance(tools, list), "tools.json must contain a JSON array")
+    require(len(tools) >= 80, f"expected at least 80 tools, found {len(tools)}")
+    names = [tool.get("name") for tool in tools]
+    require(all(names), "every tool must have a name")
+    require(len(names) == len(set(names)), "tools.json contains duplicate tool names")
+    print(f"PASS catalogue: {len(tools)} tools")
+
+    sitemap_text = resources["sitemap.xml"].decode("utf-8")
+    ElementTree.fromstring(sitemap_text)
+    for path in ("tool-finder.html", "osint-tools.html", "geoint-guide.html", "ar/", "tr/"):
+        expected = EXPECTED_PRODUCTION_ROOT + path
+        require(expected in sitemap_text, f"sitemap.xml is missing {expected}")
+    print("PASS sitemap: valid XML and critical routes present")
+
+    feed_text = resources["feed.xml"].decode("utf-8")
+    ElementTree.fromstring(feed_text)
+    require("OSINT Roadmap" in feed_text, "feed.xml is missing project identity")
+    print("PASS feed: valid XML")
+
+    robots_text = resources["robots.txt"].decode("utf-8")
+    require("User-agent:" in robots_text, "robots.txt is missing User-agent")
+    require(
+        EXPECTED_PRODUCTION_ROOT + "sitemap.xml" in robots_text,
+        "robots.txt does not advertise the production sitemap",
+    )
+    print("PASS robots.txt: sitemap advertised")
+
+    print("Pages smoke test passed.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument("--retry-delay", type=float, default=2.0)
+    args = parser.parse_args()
+
+    try:
+        run(args.base_url, max(args.retries, 1), max(args.retry_delay, 0))
+    except (AssertionError, RuntimeError, ValueError, json.JSONDecodeError, ElementTree.ParseError) as exc:
+        print(f"SMOKE TEST FAILED: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Step 6 — Add Pages deployment smoke test

This PR makes the Pages workflow validate the exact static bundle before deployment and reuse the same smoke test against the live Pages URL after Pages is enabled.

### Local pre-deployment smoke
On PRs and relevant pushes, the workflow:
- serves `site/` over a real local HTTP server
- checks 10 critical routes, including English, Arabic and Turkish entry points
- checks `style.css`, `tools.json`, `robots.txt`, `sitemap.xml` and `feed.xml`
- parses `tools.json` and requires at least 80 unique named tools
- parses sitemap/feed as XML
- verifies critical sitemap routes and the robots sitemap declaration
- packages the exact `site/` directory with `actions/upload-pages-artifact@v5`

### Live post-deployment smoke
Once GitHub Pages is enabled, deployment runs normally and then the same script tests `steps.deployment.outputs.page_url` with retries for propagation.

### Safe behavior before step 11
Pages is currently not enabled. On non-PR runs where `repository.has_pages` is false, the deployment job is intentionally skipped after the artifact smoke test passes, and the workflow emits a notice instead of creating a false failure.

### QA result
The PR workflow completed successfully. The local HTTP smoke test passed all 10 critical pages and all 5 static resources, parsed the 80-tool catalogue, validated sitemap/feed XML and robots metadata, and successfully built/uploaded the exact `github-pages` artifact. The deployment job was correctly skipped on the PR.

The live post-deployment half is already wired and will activate automatically once Pages is enabled in step 11.